### PR TITLE
Global analytic budgets & projections PRJ-383

### DIFF
--- a/src/imio/project/core/browser/analytic_budget_datagridfield_display.pt
+++ b/src/imio/project/core/browser/analytic_budget_datagridfield_display.pt
@@ -28,8 +28,8 @@
         <tr tal:repeat="year python:sorted(years.keys())">
           <tal:defines tal:define="line python:years[year]">
           <td class="analytic_budget_year" tal:content="year">Year</td>
-          <td class="analytic_budget_revenues" tal:content="line/revenues">Revenues</td>
-          <td class="analytic_budget_expenses" tal:content="line/expenses">Expenses</td>
+          <td class="analytic_budget_revenues" tal:content="python: '{:+.2f}'.format(line['revenues'])">Revenues</td>
+          <td class="analytic_budget_expenses" tal:content="python: '{:+.2f}'.format(line['expenses'])">Expenses</td>
           <td class="analytic_budget_total" tal:content="line/total">Total</td>
           </tal:defines>
         </tr>

--- a/src/imio/project/core/browser/analytic_budget_datagridfield_display.pt
+++ b/src/imio/project/core/browser/analytic_budget_datagridfield_display.pt
@@ -1,0 +1,40 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag=""
+      i18n:domain="imio.project.core">
+
+<tal:comment replace="nothing">Render original template, this will render DataGridField data</tal:comment>
+<fieldset>
+  <legend i18n:translate="analytic_budget_legend_local_data">Locally encoded data</legend>
+    <tal:block replace="structure view/original_template" />
+</fieldset>
+
+<fieldset tal:define="results view/prepareAnalyticBudgetForDisplay;"
+          tal:condition="results">
+  <legend i18n:translate="analytic_budget_legend_global_data">Data taken from analytic budgets encoded in sub-element</legend>
+  <table class="listing analytic_budget_table">
+    <tal:defines define="years python: results">
+      <thead>
+        <tr>
+          <th class="nosort" i18n:translate="analytic_budget_label_year">Year</th>
+          <th class="nosort" i18n:translate="analytic_budget_label_revenues">Revenues</th>
+          <th class="nosort" i18n:translate="analytic_budget_label_expenses">Expenses</th>
+          <th class="nosort" i18n:translate="analytic_budget_label_total">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr tal:repeat="year python:sorted(years.keys())">
+          <tal:defines tal:define="line python:years[year]">
+          <td class="analytic_budget_year" tal:content="year">Year</td>
+          <td class="analytic_budget_revenues" tal:content="line/revenues">Revenues</td>
+          <td class="analytic_budget_expenses" tal:content="line/expenses">Expenses</td>
+          <td class="analytic_budget_total" tal:content="line/total">Total</td>
+          </tal:defines>
+        </tr>
+      </tbody>
+    </tal:defines>
+  </table>
+</fieldset>
+</html>

--- a/src/imio/project/core/browser/analytic_budget_datagridfield_display.pt
+++ b/src/imio/project/core/browser/analytic_budget_datagridfield_display.pt
@@ -6,7 +6,7 @@
       i18n:domain="imio.project.core">
 
 <tal:comment replace="nothing">Render original template, this will render DataGridField data</tal:comment>
-<fieldset>
+<fieldset tal:condition="view/original_template">
   <legend i18n:translate="analytic_budget_legend_local_data">Locally encoded data</legend>
     <tal:block replace="structure view/original_template" />
 </fieldset>

--- a/src/imio/project/core/browser/behaviors.py
+++ b/src/imio/project/core/browser/behaviors.py
@@ -3,8 +3,10 @@
 from collective.z3cform.datagridfield import DictRow
 from collective.z3cform.datagridfield.datagridfield import DataGridField
 from imio.project.core import _
+from imio.project.core.browser.widgets import AnalyticBudgetDataGridField
+from imio.project.core.browser.widgets import ProjectionDataGridField
 from imio.project.core.content.project import default_year
-from plone.autoform import directives
+from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
@@ -13,7 +15,22 @@ from zope.component import adapter
 from zope.interface import Interface
 from zope.interface import implementer
 from zope.interface import provider
-from plone.autoform import directives as form
+from z3c.form import interfaces
+from z3c.form.widget import FieldWidget
+
+
+@implementer(interfaces.IFieldWidget)
+def AnalyticBudgetDataGridFieldFactory(field, request):
+    """IFieldWidget factory for DataGridField using the 'AnalyticBudgetDataGridField' widget."""
+    widget = AnalyticBudgetDataGridField(request)
+    return FieldWidget(field, widget)
+
+
+@implementer(interfaces.IFieldWidget)
+def ProjectionDataGridFieldFactory(field, request):
+    """IFieldWidget factory for DataGridField using the 'ProjectionDataGridField' widget."""
+    widget = ProjectionDataGridField(request)
+    return FieldWidget(field, widget)
 
 
 class IAnalyticBudgetSchema(Interface):
@@ -106,7 +123,7 @@ class IAnalyticBudget(model.Schema):
             title=_("Analytic budget"), schema=IAnalyticBudgetSchema, required=False
         ),
     )
-    directives.widget("analytic_budget", DataGridField, display_table_css_class="listing nosort")
+    form.widget("analytic_budget", AnalyticBudgetDataGridFieldFactory, display_table_css_class="listing nosort")
 
     projection = schema.List(
         title=_(u"Projection"),
@@ -116,7 +133,7 @@ class IAnalyticBudget(model.Schema):
             title=_("Projection"), schema=IProjectionSchema, required=False
         ),
     )
-    directives.widget("projection", DataGridField, display_table_css_class="listing nosort")
+    form.widget("projection", ProjectionDataGridFieldFactory, display_table_css_class="listing nosort")
 
     form.order_before(projection='budget')
     form.order_before(analytic_budget='budget')

--- a/src/imio/project/core/browser/budgetinfos_datagridfield_display.pt
+++ b/src/imio/project/core/browser/budgetinfos_datagridfield_display.pt
@@ -6,7 +6,7 @@
       i18n:domain="imio.project.core">
 
 <tal:comment replace="nothing">Render original template, this will render DataGridField data</tal:comment>
-<fieldset>
+<fieldset tal:condition="view/original_template">
   <legend i18n:translate="budgetinfos_legend_local_data">Locally encoded data</legend>
     <tal:block replace="structure view/original_template" />
 </fieldset>

--- a/src/imio/project/core/browser/controlpanel.py
+++ b/src/imio/project/core/browser/controlpanel.py
@@ -137,6 +137,7 @@ class IImioProjectSettings(Interface):
     project_budget_states = schema.List(
         title=_(u"${type} budget globalization states", mapping={'type': _('Project')}),
         description=_(u'Put states on the right for which you want to globalize budget fields.'),
+        required=False,
         value_type=schema.Choice(vocabulary=u'imio.project.core.ProjectStatesVocabulary'),
     )
 

--- a/src/imio/project/core/browser/controlpanel.py
+++ b/src/imio/project/core/browser/controlpanel.py
@@ -3,9 +3,11 @@
 from imio.helpers.content import get_schema_fields
 from imio.project.core import _
 from imio.project.core import _tr
+from plone import api
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
 from plone.app.registry.browser.controlpanel import RegistryEditForm
 from plone.z3cform import layout
+from Products.CMFPlone.utils import safe_unicode
 from z3c.form import form
 from zope import schema
 from zope.interface import implements
@@ -106,6 +108,22 @@ class ProjectFieldsVocabulary(object):
                                  field_constraints)
 
 
+class ProjectStatesVocabulary(object):
+    """ Project workflow states """
+    implements(IVocabularyFactory)
+
+    def __call__(self, context):
+
+        pw = api.portal.get_tool('portal_workflow')
+
+        for workflow in pw.getWorkflowsFor('project'):
+            states = [value for value in workflow.states.values()]
+        terms = []
+        for state in states:
+            terms.append(SimpleTerm(state.id, title=_tr(safe_unicode(state.title), domain='plone')))
+        return SimpleVocabulary(terms)
+
+
 class IImioProjectSettings(Interface):
     """"""
 
@@ -114,6 +132,12 @@ class IImioProjectSettings(Interface):
         description=_(u'Put fields on the right to display it. Flags are : ...'),
         value_type=schema.Choice(vocabulary=u'imio.project.core.ProjectFieldsVocabulary'),
 #        value_type=schema.Choice(source=IMFields),  # a source is not managed by registry !!
+    )
+
+    project_budget_states = schema.List(
+        title=_(u"${type} budget globalization states", mapping={'type': _('Project')}),
+        description=_(u'Put states on the right for which you want to globalize budget fields.'),
+        value_type=schema.Choice(vocabulary=u'imio.project.core.ProjectStatesVocabulary'),
     )
 
     @invariant

--- a/src/imio/project/core/browser/controlpanel.py
+++ b/src/imio/project/core/browser/controlpanel.py
@@ -96,6 +96,11 @@ def position_check(data, constraints):
         raise Invalid(_(u'Some fields have to be at a specific position: ${msg}', mapping={'msg': msg}))
 
 
+def get_budget_states(portal_type):
+    return api.portal.get_registry_record('imio.project.settings.{}_budget_states'.format(portal_type),
+                                          default=[]) or []
+
+
 class ProjectFieldsVocabulary(object):
     implements(IVocabularyFactory)
 

--- a/src/imio/project/core/browser/projection_datagridfield_display.pt
+++ b/src/imio/project/core/browser/projection_datagridfield_display.pt
@@ -5,7 +5,9 @@
       tal:omit-tag=""
       i18n:domain="imio.project.core">
 
-<fieldset tal:define="lines view/prepareProjectionForSingleDisplay;" tal:condition="lines">
+<fieldset tal:define="ret python: view.prepareProjectionForSingleDisplay();
+                      lines python: ret[0];"
+          tal:condition="lines">
   <legend i18n:translate="projection_legend_local_data">Locally encoded data</legend>
   <table class="listing projection_table">
     <thead>
@@ -20,7 +22,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr tal:repeat="line python:sorted(lines.keys())">
+      <tr tal:repeat="line python: ret[1]">
         <td class="projection_service" tal:content="line/service">Service</td>
         <td class="projection_btype" tal:content="line/btype">R/D</td>
         <td class="projection_group" tal:content="line/group">Eco group</td>

--- a/src/imio/project/core/browser/projection_datagridfield_display.pt
+++ b/src/imio/project/core/browser/projection_datagridfield_display.pt
@@ -5,34 +5,32 @@
       tal:omit-tag=""
       i18n:domain="imio.project.core">
 
-<fieldset>
+<fieldset tal:define="lines view/prepareProjectionForSingleDisplay;" tal:condition="lines">
   <legend i18n:translate="projection_legend_local_data">Locally encoded data</legend>
   <table class="listing projection_table">
-    <tal:defines define="lines view/prepareProjectionForSingleDisplay;">
-      <thead>
-        <tr>
-          <th class="nosort" i18n:translate="projection_label_service">Service</th>
-          <th class="nosort" i18n:translate="projection_label_btype">R/D</th>
-          <th class="nosort" i18n:translate="projection_label_group">Eco group</th>
-          <th class="nosort" i18n:translate="projection_label_title">Title</th>
-          <tal:loop_years repeat="year view/budget_years">
-            <th class="nosort" tal:content="year"></th>
-          </tal:loop_years>
-        </tr>
-      </thead>
-      <tbody>
-        <tr tal:repeat="line python:sorted(lines.keys())">
-          <td class="projection_service" tal:content="line/service">Service</td>
-          <td class="projection_btype" tal:content="line/btype">R/D</td>
-          <td class="projection_group" tal:content="line/group">Eco group</td>
-          <td class="projection_title" tal:content="line/title">Title</td>
-          <tal:loop tal:define="year_amounts python:lines[line]"
-                    tal:repeat="year year_amounts">
-            <td class="projection_amount" tal:content="python:year_amounts[year]">Year</td>
-          </tal:loop>
-        </tr>
-      </tbody>
-    </tal:defines>
+    <thead>
+      <tr>
+        <th class="nosort" i18n:translate="projection_label_service">Service</th>
+        <th class="nosort" i18n:translate="projection_label_btype">R/D</th>
+        <th class="nosort" i18n:translate="projection_label_group">Eco group</th>
+        <th class="nosort" i18n:translate="projection_label_title">Title</th>
+        <tal:loop_years repeat="year view/budget_years">
+          <th class="nosort" tal:content="year"></th>
+        </tal:loop_years>
+      </tr>
+    </thead>
+    <tbody>
+      <tr tal:repeat="line python:sorted(lines.keys())">
+        <td class="projection_service" tal:content="line/service">Service</td>
+        <td class="projection_btype" tal:content="line/btype">R/D</td>
+        <td class="projection_group" tal:content="line/group">Eco group</td>
+        <td class="projection_title" tal:content="line/title">Title</td>
+        <tal:loop tal:define="year_amounts python:lines[line]"
+                  tal:repeat="year year_amounts">
+          <td class="projection_amount" tal:content="python:year_amounts[year]">Year</td>
+        </tal:loop>
+      </tr>
+    </tbody>
   </table>
 </fieldset>
 

--- a/src/imio/project/core/browser/projection_datagridfield_display.pt
+++ b/src/imio/project/core/browser/projection_datagridfield_display.pt
@@ -59,12 +59,14 @@
           <td class="projection_expenses_amount" tal:content="python:years[year]['expenses']">D Amount</td>
         </tal:loop_years>
       </tr>
+    <tfoot>
       <tr>
-        <td class="projection_btype_total">TOTAL</td>
+        <td class="projection_btype_total">Total</td>
         <tal:loop_years repeat="year view/budget_years">
           <td class="projection_total_amount" tal:content="python:years[year]['total']">Total Amount</td>
         </tal:loop_years>
       </tr>
+    </tfoot>
     </tbody>
   </table>
 </fieldset>

--- a/src/imio/project/core/browser/projection_datagridfield_display.pt
+++ b/src/imio/project/core/browser/projection_datagridfield_display.pt
@@ -1,0 +1,73 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag=""
+      i18n:domain="imio.project.core">
+
+<fieldset>
+  <legend i18n:translate="projection_legend_local_data">Locally encoded data</legend>
+  <table class="listing projection_table">
+    <tal:defines define="lines view/prepareProjectionForSingleDisplay;">
+      <thead>
+        <tr>
+          <th class="nosort" i18n:translate="projection_label_service">Service</th>
+          <th class="nosort" i18n:translate="projection_label_btype">R/D</th>
+          <th class="nosort" i18n:translate="projection_label_group">Eco group</th>
+          <th class="nosort" i18n:translate="projection_label_title">Title</th>
+          <tal:loop_years repeat="year view/budget_years">
+            <th class="nosort" tal:content="year"></th>
+          </tal:loop_years>
+        </tr>
+      </thead>
+      <tbody>
+        <tr tal:repeat="line python:sorted(lines.keys())">
+          <td class="projection_service" tal:content="line/service">Service</td>
+          <td class="projection_btype" tal:content="line/btype">R/D</td>
+          <td class="projection_group" tal:content="line/group">Eco group</td>
+          <td class="projection_title" tal:content="line/title">Title</td>
+          <tal:loop tal:define="year_amounts python:lines[line]"
+                    tal:repeat="year year_amounts">
+            <td class="projection_amount" tal:content="python:year_amounts[year]">Year</td>
+          </tal:loop>
+        </tr>
+      </tbody>
+    </tal:defines>
+  </table>
+</fieldset>
+
+<fieldset tal:define="years view/prepareProjectionForMultipleDisplay;"
+          tal:condition="years">
+  <legend i18n:translate="projection_legend_global_data">Data taken from budget infos encoded in sub-element</legend>
+  <table class="listing projection_table">
+    <thead>
+      <tr>
+        <th class="nosort" i18n:translate="projection_label_btype">R/D</th>
+        <tal:loop_years repeat="year view/budget_years">
+          <th class="nosort" tal:content="year"></th>
+        </tal:loop_years>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="projection_btype_revenues">R</td>
+        <tal:loop_years repeat="year view/budget_years">
+          <td class="projection_revenues_amount" tal:content="python:years[year]['revenues']">R Amount</td>
+        </tal:loop_years>
+      </tr>
+      <tr>
+        <td class="projection_btype_expenses">D</td>
+        <tal:loop_years repeat="year view/budget_years">
+          <td class="projection_expenses_amount" tal:content="python:years[year]['expenses']">D Amount</td>
+        </tal:loop_years>
+      </tr>
+      <tr>
+        <td class="projection_btype_total">TOTAL</td>
+        <tal:loop_years repeat="year view/budget_years">
+          <td class="projection_total_amount" tal:content="python:years[year]['total']">Total Amount</td>
+        </tal:loop_years>
+      </tr>
+    </tbody>
+  </table>
+</fieldset>
+</html>

--- a/src/imio/project/core/browser/static/imio_project_core.css
+++ b/src/imio/project/core/browser/static/imio_project_core.css
@@ -12,7 +12,7 @@ table.datagridwidget-table-view input.float-field, table.datagridwidget-table-vi
 .budgetinfos_global_total, .budgetinfos_result, .budgetinfos_table TFOOT TD {
     text-align: right;
 }
-.budgetinfos_table TFOOT {
+.budgetinfos_table TFOOT, .projection_table TFOOT, td.analytic_budget_total {
     font-weight: bold;
     border-top: 1px solid grey;
 }

--- a/src/imio/project/core/browser/views.py
+++ b/src/imio/project/core/browser/views.py
@@ -318,7 +318,11 @@ class PSTImportFromEcomptes(Form):
                         'amount': amount,
                         # 'comment': u'',  Removed from schema
                     })
-                element_dx.analytic_budget = element_dx_articles
+                element_dx.analytic_budget = sorted(element_dx_articles,
+                                                    cmp=lambda x, y: cmp((x['year'], y['service'], y['btype'],
+                                                                          x['article']),
+                                                                         (y['year'], x['service'], x['btype'],
+                                                                          y['article'])))
                 modifications[element_dx.absolute_url_path()] = element_dx
 
         all_projections_xml = ecomptes_xml.findall('.//Projections')

--- a/src/imio/project/core/browser/views.py
+++ b/src/imio/project/core/browser/views.py
@@ -22,6 +22,7 @@ from z3c.form.field import Fields
 from z3c.form.form import Form
 from zope import schema
 from zope.component import getMultiAdapter
+from zope.lifecycleevent import modified
 from zope.schema.interfaces import IVocabularyFactory
 
 import logging
@@ -289,6 +290,7 @@ class PSTImportFromEcomptes(Form):
         return parsed_xml
 
     def update_pst(self, ecomptes_xml):
+        modifications = {}
         all_articles_xml = ecomptes_xml.findall('.//Articles')
         for articles_xml in all_articles_xml:
             if not articles_xml.getchildren():
@@ -317,6 +319,7 @@ class PSTImportFromEcomptes(Form):
                         # 'comment': u'',  Removed from schema
                     })
                 element_dx.analytic_budget = element_dx_articles
+                modifications[element_dx.absolute_url_path()] = element_dx
 
         all_projections_xml = ecomptes_xml.findall('.//Projections')
         for projections_xml in all_projections_xml:
@@ -347,6 +350,10 @@ class PSTImportFromEcomptes(Form):
                             'amount': amount,
                         })
                 element_dx.projection = projections
+                modifications[element_dx.absolute_url_path()] = element_dx
+
+        for path in reversed(modifications.keys()):
+            modified(modifications[path])
 
     @button.buttonAndHandler(_(u'Import'), name='import')
     def handleApply(self, action):

--- a/src/imio/project/core/browser/widgets.py
+++ b/src/imio/project/core/browser/widgets.py
@@ -222,7 +222,9 @@ class ProjectionDataGridField(DataGridField):
             amounts = res.setdefault(projection_line, {y: 0.0 for y in fixed_years})
             amounts[year] = amount
 
-        return res
+        # functools.cmp_to_key() for python 3
+        return res, sorted(res.keys(), cmp=lambda x, y: cmp((y.service, y.btype, x.group),
+                                                            (x.service, x.btype, y.group)))
 
     def prepareProjectionForMultipleDisplay(self):
         annotations = IAnnotations(self.context)

--- a/src/imio/project/core/browser/widgets.py
+++ b/src/imio/project/core/browser/widgets.py
@@ -6,6 +6,7 @@ from imio.project.core.config import CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY
 from imio.project.core.config import CHILDREN_BUDGET_INFOS_ANNOTATION_KEY
 from imio.project.core.config import CHILDREN_PROJECTIONS_ANNOTATION_KEY
 from imio.project.core.utils import getProjectSpace
+from Products.CMFPlone.utils import base_hasattr
 from zope.annotation import IAnnotations
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import queryUtility
@@ -150,10 +151,11 @@ class AnalyticBudgetDataGridField(DataGridField):
         if CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY not in annotations:
             return {}
 
-        fixed_years = [str(y) for y in getProjectSpace(self.context).budget_years or []]
         res = {}
-        for year in fixed_years:
-            res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
+# no need to have all years. Articles are defined only for the current year.
+#        fixed_years = [str(y) for y in getProjectSpace(self.context).budget_years or []]
+#        for year in fixed_years:
+#            res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
 
         for datagridfieldrecord in annotations[CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY].itervalues():
             for line in datagridfieldrecord:
@@ -198,10 +200,12 @@ class ProjectionDataGridField(DataGridField):
         return [str(y) for y in getProjectSpace(self.context).budget_years or []]
 
     def prepareProjectionForSingleDisplay(self):
+        if not base_hasattr(self.context, 'projection') or not self.context.projection:
+            return {}
+
         ProjectionLine = namedtuple('ProjectionLine', ['service', 'btype', 'group', 'title'])
         fixed_years = self.budget_years
         res = {}
-
         for line in self.context.projection:
             service = line['service']
             btype = line['btype']
@@ -215,7 +219,6 @@ class ProjectionDataGridField(DataGridField):
             amounts[year] = amount
 
         return res
-
 
     def prepareProjectionForMultipleDisplay(self):
         annotations = IAnnotations(self.context)

--- a/src/imio/project/core/browser/widgets.py
+++ b/src/imio/project/core/browser/widgets.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+from collections import namedtuple
 
 from collective.z3cform.datagridfield.datagridfield import DataGridField
+from imio.project.core.config import CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY
 from imio.project.core.config import CHILDREN_BUDGET_INFOS_ANNOTATION_KEY
+from imio.project.core.config import CHILDREN_PROJECTIONS_ANNOTATION_KEY
 from imio.project.core.utils import getProjectSpace
 from zope.annotation import IAnnotations
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
@@ -123,3 +126,120 @@ class BudgetInfosDataGridField(DataGridField):
             super_total = super_total + total
 
         return years, budget_types, res, total_by_year, total_by_budget_type, super_total
+
+
+class AnalyticBudgetDataGridField(DataGridField):
+    """Custom DataGridField widget used to display analytic budget infos"""
+
+    def render(self):
+        """
+          We override renderer so we can call original DataGridField renderer without customizing the template and add
+          our own rendered template under.
+        """
+        # render original template
+        template = DataGridField.render(self)
+        # render our own template we will display just under original one
+        if self.mode == 'display':
+            # we will display the originally rendered template in our template, so set it on self
+            self.original_template = template
+            template = ViewPageTemplateFile('analytic_budget_datagridfield_display.pt')(self)
+        return template
+
+    def prepareAnalyticBudgetForDisplay(self):
+        annotations = IAnnotations(self.context)
+        if CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY not in annotations:
+            return {}
+
+        fixed_years = [str(y) for y in getProjectSpace(self.context).budget_years or []]
+        res = {}
+        for year in fixed_years:
+            res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
+
+        for datagridfieldrecord in annotations[CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY].itervalues():
+            for line in datagridfieldrecord:
+                year = str(line['year'])
+                budget_type = line['btype'].lower()
+                amount = line['amount']
+                res_year = res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
+                if 'r' in budget_type:
+                    res_year['revenues'] += amount
+                elif 'd' in budget_type:
+                    res_year['expenses'] += amount
+
+        for amounts in res.values():
+            margin = amounts['revenues'] - amounts['expenses']
+            amounts['total'] = '{:+.1f}'.format(margin) if margin else '-'
+            for key in ('revenues', 'expenses'):
+                if not amounts[key]:
+                    amounts[key] = '-'
+
+        return res
+
+
+class ProjectionDataGridField(DataGridField):
+    """Custom DataGridField widget used to display projections"""
+
+    def render(self):
+        """
+          We override renderer so we can call original DataGridField renderer without customizing the template and add
+          our own rendered template under.
+        """
+
+        # render our own template
+        if self.mode == 'display':
+            template = ViewPageTemplateFile('projection_datagridfield_display.pt')(self)
+        else:
+            # render original template
+            template = DataGridField.render(self)
+        return template
+
+    @property
+    def budget_years(self):
+        return [str(y) for y in getProjectSpace(self.context).budget_years or []]
+
+    def prepareProjectionForSingleDisplay(self):
+        ProjectionLine = namedtuple('ProjectionLine', ['service', 'btype', 'group', 'title'])
+        fixed_years = self.budget_years
+        res = {}
+
+        for line in self.context.projection:
+            service = line['service']
+            btype = line['btype']
+            group = line['group']
+            title = line['title']
+            year = str(line['year'])
+            amount = line['amount']
+
+            projection_line = ProjectionLine(service, btype, group, title)
+            amounts = res.setdefault(projection_line, {y: 0.0 for y in fixed_years})
+            amounts[year] = amount
+
+        return res
+
+
+    def prepareProjectionForMultipleDisplay(self):
+        annotations = IAnnotations(self.context)
+        if CHILDREN_PROJECTIONS_ANNOTATION_KEY not in annotations:
+            return {}
+
+        fixed_years = self.budget_years
+        res = {}
+        for year in fixed_years:
+            res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
+
+        for datagridfieldrecord in annotations[CHILDREN_PROJECTIONS_ANNOTATION_KEY].itervalues():
+            for line in datagridfieldrecord:
+                year = str(line['year'])
+                budget_type = line['btype'].lower()
+                amount = line['amount']
+                res_year = res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
+                if 'r' in budget_type:
+                    res_year['revenues'] += amount
+                elif 'd' in budget_type:
+                    res_year['expenses'] += amount
+
+        for amounts in res.values():
+            margin = amounts['revenues'] - amounts['expenses']
+            amounts['total'] = '{:+.1f}'.format(margin) if margin else '0.0'
+
+        return res

--- a/src/imio/project/core/browser/widgets.py
+++ b/src/imio/project/core/browser/widgets.py
@@ -21,8 +21,10 @@ class BudgetInfosDataGridField(DataGridField):
           We override renderer so we can call original DataGridField renderer without customizing the template and add
           our own rendered template under.
         """
+        template = u''
         # render original template
-        template = DataGridField.render(self)
+        if self.mode != 'display' or (base_hasattr(self.context, 'budget') and self.context.budget):
+            template = DataGridField.render(self)
         # render our own template we will display just under original one
         if self.mode == 'display':
             # we will display the originally rendered template in our template, so set it on self
@@ -137,8 +139,10 @@ class AnalyticBudgetDataGridField(DataGridField):
           We override renderer so we can call original DataGridField renderer without customizing the template and add
           our own rendered template under.
         """
+        template = u''
         # render original template
-        template = DataGridField.render(self)
+        if self.mode != 'display' or (base_hasattr(self.context, 'analytic_budget') and self.context.analytic_budget):
+            template = DataGridField.render(self)
         # render our own template we will display just under original one
         if self.mode == 'display':
             # we will display the originally rendered template in our template, so set it on self

--- a/src/imio/project/core/browser/widgets.py
+++ b/src/imio/project/core/browser/widgets.py
@@ -225,10 +225,10 @@ class ProjectionDataGridField(DataGridField):
         if CHILDREN_PROJECTIONS_ANNOTATION_KEY not in annotations:
             return {}
 
-        fixed_years = self.budget_years
+        # fixed_years = self.budget_years
         res = {}
-        for year in fixed_years:
-            res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
+        # for year in fixed_years:
+        #     res.setdefault(year, {'revenues': 0.0, 'expenses': 0.0})
 
         for datagridfieldrecord in annotations[CHILDREN_PROJECTIONS_ANNOTATION_KEY].itervalues():
             for line in datagridfieldrecord:

--- a/src/imio/project/core/browser/widgets.py
+++ b/src/imio/project/core/browser/widgets.py
@@ -174,7 +174,7 @@ class AnalyticBudgetDataGridField(DataGridField):
 
         for amounts in res.values():
             margin = amounts['revenues'] - amounts['expenses']
-            amounts['total'] = '{:+.1f}'.format(margin) if margin else '-'
+            amounts['total'] = '{:+.2f}'.format(margin) if margin else '-'
             for key in ('revenues', 'expenses'):
                 if not amounts[key]:
                     amounts[key] = '-'
@@ -247,6 +247,6 @@ class ProjectionDataGridField(DataGridField):
 
         for amounts in res.values():
             margin = amounts['revenues'] - amounts['expenses']
-            amounts['total'] = '{:+.1f}'.format(margin) if margin else '0.0'
+            amounts['total'] = '{:+.2f}'.format(margin) if margin else '0.0'
 
         return res

--- a/src/imio/project/core/config.py
+++ b/src/imio/project/core/config.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 
 # the annotation key where we store budget infos coming from children on a project
+CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY = 'imio.project.core-analyticbudgets'
 CHILDREN_BUDGET_INFOS_ANNOTATION_KEY = 'imio.project.core-budgetinfos'
+CHILDREN_PROJECTIONS_ANNOTATION_KEY = 'imio.project.core-projections'

--- a/src/imio/project/core/config.py
+++ b/src/imio/project/core/config.py
@@ -4,3 +4,9 @@
 CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY = 'imio.project.core-analyticbudgets'
 CHILDREN_BUDGET_INFOS_ANNOTATION_KEY = 'imio.project.core-budgetinfos'
 CHILDREN_PROJECTIONS_ANNOTATION_KEY = 'imio.project.core-projections'
+
+SUMMARIZED_FIELDS = {
+    'budget': CHILDREN_BUDGET_INFOS_ANNOTATION_KEY,
+    'analytic_budget': CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY,
+    'projection': CHILDREN_PROJECTIONS_ANNOTATION_KEY,
+}

--- a/src/imio/project/core/configure.zcml
+++ b/src/imio/project/core/configure.zcml
@@ -81,4 +81,9 @@
         factory="imio.project.core.browser.controlpanel.ProjectFieldsVocabulary"
         />
 
+    <utility
+        name="imio.project.core.ProjectStatesVocabulary"
+        factory="imio.project.core.browser.controlpanel.ProjectStatesVocabulary"
+        />
+
 </configure>

--- a/src/imio/project/core/events.py
+++ b/src/imio/project/core/events.py
@@ -3,9 +3,7 @@
 from OFS.Application import Application
 from imio.helpers.cache import cleanRamCacheFor
 from imio.project.core.browser.controlpanel import field_constraints
-from imio.project.core.config import CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY as CABAK
-from imio.project.core.config import CHILDREN_BUDGET_INFOS_ANNOTATION_KEY as CBIAK
-from imio.project.core.config import CHILDREN_PROJECTIONS_ANNOTATION_KEY as CPAK
+from imio.project.core.config import SUMMARIZED_FIELDS
 from imio.project.core.content.project import IProject
 from imio.project.core.utils import getProjectSpace
 from plone import api
@@ -22,12 +20,6 @@ Move oo: onMovedProject on act, onMovedProject on oo, onModifyProject on os1, on
 Copy act: onAddProject on act2, onModifyProject on oo
 Copy oo: onAddProject on act2, onAddProject on 002, onModifyProject on os
 """
-
-summarized_fields = {
-    'budget': CBIAK,
-    'analytic_budget': CABAK,
-    'projection': CPAK,
-}
 
 
 def _updateSummarizedFields(obj, fields=None):
@@ -51,7 +43,7 @@ def _updateSummarizedFields(obj, fields=None):
 
     # retro-compatible with migration to 0.2
     if not fields:
-        fields = summarized_fields
+        fields = SUMMARIZED_FIELDS
 
     pw = obj.portal_workflow
     obj_uid = obj.UID()
@@ -96,7 +88,7 @@ def _cleanParentsFields(obj, parent=None):
     obj_annotations = IAnnotations(obj)
     uids_to_remove = {}
 
-    for field_id, annotation_key in summarized_fields.items():
+    for field_id, annotation_key in SUMMARIZED_FIELDS.items():
         uids_to_remove_for_field = [obj.UID()]
         if annotation_key in obj_annotations:
             # remove obj's children too
@@ -114,7 +106,7 @@ def _cleanParentsFields(obj, parent=None):
     while not parent.portal_type == 'projectspace':
         parent_annotations = IAnnotations(parent)
 
-        for field_id, annotation_key in summarized_fields.items():
+        for field_id, annotation_key in SUMMARIZED_FIELDS.items():
             if annotation_key in parent_annotations:
                 # we remove all contained uids from annotation (needed when the state is backed to initial state)
                 for uid in uids_to_remove[field_id]:

--- a/src/imio/project/core/events.py
+++ b/src/imio/project/core/events.py
@@ -3,7 +3,9 @@
 from OFS.Application import Application
 from imio.helpers.cache import cleanRamCacheFor
 from imio.project.core.browser.controlpanel import field_constraints
+from imio.project.core.config import CHILDREN_ANALYTIC_BUDGETS_ANNOTATION_KEY as CABAK
 from imio.project.core.config import CHILDREN_BUDGET_INFOS_ANNOTATION_KEY as CBIAK
+from imio.project.core.config import CHILDREN_PROJECTIONS_ANNOTATION_KEY as CPAK
 from imio.project.core.content.project import IProject
 from imio.project.core.utils import getProjectSpace
 from plone import api
@@ -21,12 +23,20 @@ Copy act: onAddProject on act2, onModifyProject on oo
 Copy oo: onAddProject on act2, onAddProject on 002, onModifyProject on os
 """
 
+summarized_fields = {
+    'budget': CBIAK,
+    'analytic_budget': CABAK,
+    'projection': CPAK,
+}
 
-def _updateParentsBudgetInfos(obj):
+
+def _updateSummarizedFields(obj, fields=None):
     """
-      Update budget infos on every parents, going up until the parent is the projectspace.
+      Update each summarized field on every parents, going up until the parent is the projectspace.
       Exception made if the parent is on initial state
     """
+
+    # example for Budget Infos field:
     # formatBudgetInfos : take current obj budget infos and budget infos defined on children
     # that have been saved in current object annotations with key CHILDREN_BUDGET_INFOS_ANNOTATION_KEY
     # stored data will be something like :
@@ -39,58 +49,81 @@ def _updateParentsBudgetInfos(obj):
     #                                       {'amount': 125.0, 'budget_type': 'ville', 'year': 2013}]
     # }
 
-    formattedBudgetInfos = {}
+    # retro-compatible with migration to 0.2
+    if not fields:
+        fields = summarized_fields
+
     pw = obj.portal_workflow
-    objUID = obj.UID()
-    # we take the budget infos saved on obj annotation
+    obj_uid = obj.UID()
+    # we take the field data saved on obj annotation
     obj_annotations = IAnnotations(obj)
-    if CBIAK in obj_annotations:
-        formattedBudgetInfos = dict(obj_annotations[CBIAK])
-    # add self in budgetInfos if not empty
-    if obj.budget:
-        formattedBudgetInfos[objUID] = obj.budget
+    formatted_fields = {}
+    for field_id, annotation_key in fields.items():
+        formatted_field = {}
+        if annotation_key in obj_annotations:
+            formatted_field = dict(obj_annotations[annotation_key])
+        # add self in field if not empty
+        if getattr(obj, field_id, None):
+            formatted_field[obj_uid] = getattr(obj, field_id, None)
+        formatted_fields[field_id] = formatted_field
 
     parent = obj.aq_inner.aq_parent
     while not parent.portal_type == 'projectspace':
         workflows = pw.getWorkflowsFor(parent)
-        # if parent state is initial_state, we don't set children budget
+        # if parent state is initial_state, we don't set children field
         if workflows and workflows[0].initial_state == pw.getInfoFor(parent, 'review_state'):
             break
         parent_annotations = IAnnotations(parent)
-        if not CBIAK in parent_annotations:
-            parent_annotations[CBIAK] = {}
-        # warning, we need to pass by an intermediate value then assign it using dict()
-        # as new annotations, or annotations are lost upon Zope restart...
-        new_annotations = parent_annotations[CBIAK]
-        new_annotations.update(formattedBudgetInfos)
-        parent_annotations[CBIAK] = dict(new_annotations)
+
+        for field_id, annotation_key in fields.items():
+            if annotation_key not in parent_annotations:
+                parent_annotations[annotation_key] = {}
+            # warning, we need to pass by an intermediate value then assign it using dict()
+            # as new annotations, or annotations are lost upon Zope restart...
+            new_annotations = parent_annotations[annotation_key]
+            new_annotations.update(formatted_fields[field_id])
+            parent_annotations[annotation_key] = dict(new_annotations)
+
         parent = parent.aq_inner.aq_parent
 
 
-def _cleanParentsBudgetInfos(obj, parent=None):
+def _cleanParentsFields(obj, parent=None):
     """
-      Update budget infos on every parents, cleaning sub objects info.
+      Update field data on every parents, cleaning sub objects info.
       When p_parent, it's a move. We don't modify obj but work on old parent
     """
-    uids = [obj.UID()]
+    # uids_to_remove = [obj.UID()]
     obj_annotations = IAnnotations(obj)
-    if CBIAK in obj_annotations:
-        uids.extend(obj_annotations[CBIAK].keys())
-        if parent is None:
-            obj_annotations[CBIAK] = {}
+    uids_to_remove = {}
+
+    for field_id, annotation_key in summarized_fields.items():
+        uids_to_remove_for_field = [obj.UID()]
+        if annotation_key in obj_annotations:
+            # remove obj's children too
+            uids_to_remove_for_field.extend(obj_annotations[annotation_key].keys())
+            if parent is None:
+                obj_annotations[annotation_key] = {}
+        uids_to_remove[field_id] = uids_to_remove_for_field
+
     if parent is None:
         parent = obj.aq_inner.aq_parent
+
     if isinstance(parent, Application):
         return  # This can happen when we try to remove a plone object
+
     while not parent.portal_type == 'projectspace':
         parent_annotations = IAnnotations(parent)
-        if CBIAK in parent_annotations:
-            # we remove all contained uids from annotation (needed when the state is backed to initial state)
-            for uid in uids:
-                if uid in parent_annotations[CBIAK]:
-                    del parent_annotations[CBIAK][uid]
-            # We have to set new dict to be persisted in annotation
-            parent_annotations[CBIAK] = dict(parent_annotations[CBIAK])
+
+        for field_id, annotation_key in summarized_fields.items():
+            if annotation_key in parent_annotations:
+                # we remove all contained uids from annotation (needed when the state is backed to initial state)
+                for uid in uids_to_remove[field_id]:
+                    if uid in parent_annotations[annotation_key]:
+                        del parent_annotations[annotation_key][uid]
+
+                # We have to set new dict to be persisted in annotation
+                parent_annotations[annotation_key] = dict(parent_annotations[annotation_key])
+
         parent = parent.aq_inner.aq_parent
 
 
@@ -98,11 +131,11 @@ def onAddProject(obj, event):
     """
       Handler when a project is added
     """
-    # Update budget infos on every parents
+    # Update field data on every parents
     pw = obj.portal_workflow
     workflows = pw.getWorkflowsFor(obj)
     if not workflows or workflows[0].initial_state != pw.getInfoFor(obj, 'review_state'):
-        _updateParentsBudgetInfos(obj)
+        _updateSummarizedFields(obj)
     # compute reference number
     if not base_hasattr(obj, 'symbolic_link'):
         projectspace = getProjectSpace(obj)
@@ -115,11 +148,11 @@ def onModifyProject(obj, event):
     """
       Handler when a project is modified
     """
-    # Update budget infos on every parents
+    # Update field data on every parents
     pw = obj.portal_workflow
     workflows = pw.getWorkflowsFor(obj)
     if not workflows or workflows[0].initial_state != pw.getInfoFor(obj, 'review_state'):
-        _updateParentsBudgetInfos(obj)
+        _updateSummarizedFields(obj)
 
 
 def onTransitionProject(obj, event):
@@ -131,18 +164,18 @@ def onTransitionProject(obj, event):
         return
     pw = obj.portal_workflow
     workflows = pw.getWorkflowsFor(obj)
-    # Update budget infos on parents
+    # Update field data on parents
     if event.old_state.title == workflows[0].initial_state and event.new_state.title != workflows[0].initial_state:
-        _updateParentsBudgetInfos(obj)
+        _updateSummarizedFields(obj)
     elif event.new_state.title == workflows[0].initial_state and event.old_state.title != workflows[0].initial_state:
-        _cleanParentsBudgetInfos(obj)
+        _cleanParentsFields(obj)
 
 
 def onRemoveProject(obj, event):
     """
         When a project is removed
     """
-    _cleanParentsBudgetInfos(obj)
+    _cleanParentsFields(obj)
 
 
 def onMoveProject(obj, event):
@@ -158,10 +191,10 @@ def onMoveProject(obj, event):
         return
     pw = obj.portal_workflow
     workflows = pw.getWorkflowsFor(obj)
-    # Update budget infos on old and new parents
+    # Update field data on old and new parents
     if not workflows or workflows[0].initial_state != pw.getInfoFor(obj, 'review_state'):
-        _cleanParentsBudgetInfos(obj, parent=event.oldParent)
-        _updateParentsBudgetInfos(obj)
+        _cleanParentsFields(obj, parent=event.oldParent)
+        _updateSummarizedFields(obj)
 
 
 def onModifyProjectSpace(obj, event):

--- a/src/imio/project/core/locales/en/LC_MESSAGES/imio.project.core.po
+++ b/src/imio/project/core/locales/en/LC_MESSAGES/imio.project.core.po
@@ -269,7 +269,37 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: ./browser/behaviors.zcml:14
+#. Default: "Expenses"
+#: ../browser/analytic_budget_datagridfield_display.pt:23
+msgid "analytic_budget_label_expenses"
+msgstr ""
+
+#. Default: "Revenues"
+#: ../browser/analytic_budget_datagridfield_display.pt:22
+msgid "analytic_budget_label_revenues"
+msgstr ""
+
+#. Default: "Total"
+#: ../browser/analytic_budget_datagridfield_display.pt:24
+msgid "analytic_budget_label_total"
+msgstr ""
+
+#. Default: "Year"
+#: ../browser/analytic_budget_datagridfield_display.pt:21
+msgid "analytic_budget_label_year"
+msgstr ""
+
+#. Default: "Data taken from analytic budgets encoded in sub-element"
+#: ../browser/analytic_budget_datagridfield_display.pt:16
+msgid "analytic_budget_legend_global_data"
+msgstr ""
+
+#. Default: "Locally encoded data"
+#: ../browser/analytic_budget_datagridfield_display.pt:10
+msgid "analytic_budget_legend_local_data"
+msgstr ""
+
+#: ../browser/behaviors.zcml:14
 msgid "behavior.AnalyticBudget"
 msgstr ""
 
@@ -305,6 +335,32 @@ msgstr ""
 msgid "imio.project.core tests"
 msgstr ""
 
-#: ./browser/controlpanel.py:55
-msgid "project"
+#. Default: "R/D"
+#: ../browser/projection_datagridfield_display.pt:15
+msgid "projection_label_btype"
+msgstr ""
+
+#. Default: "Eco group"
+#: ../browser/projection_datagridfield_display.pt:16
+msgid "projection_label_group"
+msgstr ""
+
+#. Default: "Service"
+#: ../browser/projection_datagridfield_display.pt:14
+msgid "projection_label_service"
+msgstr ""
+
+#. Default: "Title"
+#: ../browser/projection_datagridfield_display.pt:17
+msgid "projection_label_title"
+msgstr ""
+
+#. Default: "Data taken from budget infos encoded in sub-element"
+#: ../browser/projection_datagridfield_display.pt:41
+msgid "projection_legend_global_data"
+msgstr ""
+
+#. Default: "Locally encoded data"
+#: ../browser/projection_datagridfield_display.pt:9
+msgid "projection_legend_local_data"
 msgstr ""

--- a/src/imio/project/core/locales/en/LC_MESSAGES/imio.project.core.po
+++ b/src/imio/project/core/locales/en/LC_MESSAGES/imio.project.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-24 14:16+0000\n"
+"POT-Creation-Date: 2020-03-27 14:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,11 @@ msgstr ""
 "Domain: imio.project.core\n"
 "X-is-fallback-for: en-au en-ca en-gb en-us\n"
 
-#: ./browser/controlpanel.py:113
+#: ./browser/controlpanel.py:138
+msgid "${type} budget globalization states"
+msgstr ""
+
+#: ./browser/controlpanel.py:131
 msgid "${type} fields display"
 msgstr ""
 
@@ -23,12 +27,12 @@ msgstr ""
 msgid "'${fld}' at position ${i}"
 msgstr ""
 
-#: ./browser/behaviors.py:47
-#: ./content/project.py:89
+#: ./browser/behaviors.py:64
+#: ./content/project.py:106
 msgid "Amount"
 msgstr ""
 
-#: ./browser/behaviors.py:102
+#: ./browser/behaviors.py:119
 msgid "Analytic budget"
 msgstr ""
 
@@ -40,31 +44,31 @@ msgstr ""
 msgid "Behavior with analytic budget fields"
 msgstr ""
 
-#: ./content/project.py:119
+#: ./content/project.py:146
 msgid "Budget"
 msgstr "Budget"
 
-#: ./browser/behaviors.py:38
+#: ./browser/behaviors.py:55
 msgid "Budget Article"
 msgstr ""
 
-#: ./browser/behaviors.py:67
+#: ./browser/behaviors.py:84
 msgid "Budget Group"
 msgstr ""
 
-#: ./browser/behaviors.py:30
+#: ./browser/behaviors.py:47
 msgid "Budget Service"
 msgstr ""
 
-#: ./browser/behaviors.py:43
+#: ./browser/behaviors.py:60
 msgid "Budget Title"
 msgstr ""
 
-#: ./browser/behaviors.py:34
+#: ./browser/behaviors.py:51
 msgid "Budget Type"
 msgstr ""
 
-#: ./content/project.py:130
+#: ./content/project.py:157
 msgid "Budget comments"
 msgstr ""
 
@@ -76,11 +80,11 @@ msgstr ""
 msgid "Budget types values"
 msgstr ""
 
-#: ./content/project.py:78
+#: ./content/project.py:95
 msgid "Budget_type"
 msgstr ""
 
-#: ./content/project.py:105
+#: ./content/project.py:131
 msgid "Categories"
 msgstr ""
 
@@ -88,7 +92,7 @@ msgstr ""
 msgid "Categories values"
 msgstr "Categories values"
 
-#: ./content/project.py:225
+#: ./content/project.py:252
 msgid "Comments"
 msgstr "Comments"
 
@@ -96,11 +100,11 @@ msgstr "Comments"
 msgid "Current fiscal year"
 msgstr ""
 
-#: ./content/project.py:185
+#: ./content/project.py:212
 msgid "Effective begin date"
 msgstr "Effective begin date"
 
-#: ./content/project.py:201
+#: ./content/project.py:228
 msgid "Effective end date"
 msgstr "Effective end date"
 
@@ -108,15 +112,15 @@ msgstr "Effective end date"
 msgid "Enter one different value by row. Label is the displayed value. Key is the stored value: in lowercase, without space."
 msgstr "Enter one different value by row. Label is the displayed value. Key is the stored value: in lowercase, without space."
 
-#: ./content/project.py:167
+#: ./content/project.py:194
 msgid "Enter one indicator by row. Value is a number. Label must precise the signification of this number."
 msgstr "Enter one indicator by row. Value is a number. Label must precise the signification of this number."
 
-#: ./content/project.py:61
+#: ./content/project.py:78
 msgid "Expected value"
 msgstr "Expected value"
 
-#: ./content/project.py:159
+#: ./content/project.py:186
 msgid "Extra concerned people"
 msgstr "Extra concerned people"
 
@@ -124,15 +128,15 @@ msgstr "Extra concerned people"
 msgid "INS Code"
 msgstr ""
 
-#: ./browser/views.py:331
+#: ./browser/views.py:358
 msgid "Import"
 msgstr ""
 
-#: ./browser/views.py:258
+#: ./browser/views.py:279
 msgid "Import data from eComptes"
 msgstr ""
 
-#: ./configure.zcml:31
+#: ./configure.zcml:32
 msgid "Installs the imio.project.core add-on."
 msgstr ""
 
@@ -140,7 +144,7 @@ msgstr ""
 msgid "Key"
 msgstr "Key"
 
-#: ./content/project.py:58
+#: ./content/project.py:75
 #: ./content/projectspace.py:138
 msgid "Label"
 msgstr "Label"
@@ -149,31 +153,27 @@ msgstr "Label"
 msgid "Last reference number"
 msgstr ""
 
-#: ./content/project.py:139
+#: ./content/project.py:166
 msgid "Manager"
 msgstr "Manager"
 
-#: ./browser/controlpanel.py:72
+#: ./browser/controlpanel.py:74
 msgid "Missing mandatory fields: ${msg}"
 msgstr ""
 
-#: ./content/project.py:216
+#: ./content/project.py:243
 msgid "Observation"
 msgstr ""
 
-#: ./content/project.py:177
+#: ./content/project.py:204
 msgid "Planned begin date"
 msgstr "Planned begin date"
 
-#: ./content/project.py:193
+#: ./content/project.py:220
 msgid "Planned end date"
 msgstr "Planned end date"
 
-#: ./content/project.py:217
-msgid "Prior determination"
-msgstr ""
-
-#: ./content/project.py:113
+#: ./content/project.py:140
 msgid "Priority"
 msgstr "Priority"
 
@@ -181,20 +181,20 @@ msgstr "Priority"
 msgid "Priority values"
 msgstr "Priority values"
 
-#: ./content/project.py:209
+#: ./content/project.py:236
 msgid "Progress"
 msgstr "Progress"
 
-#: ./content/project.py:210
+#: ./content/project.py:237
 msgid "Progress estimation in %."
 msgstr "Progress estimation in %."
 
-#: ./browser/controlpanel.py:113
+#: ./browser/controlpanel.py:131
 #: ./profiles/default/types/project.xml
 msgid "Project"
 msgstr "Project"
 
-#: ./browser/controlpanel.py:131
+#: ./browser/controlpanel.py:155
 #: ./profiles/default/controlpanel.xml
 msgid "Project settings"
 msgstr ""
@@ -203,39 +203,43 @@ msgstr ""
 msgid "Project space"
 msgstr "Project space"
 
-#: ./browser/behaviors.py:112
+#: ./browser/behaviors.py:129
 msgid "Projection"
 msgstr ""
 
-#: ./browser/controlpanel.py:114
+#: ./browser/controlpanel.py:132
 msgid "Put fields on the right to display it. Flags are : ..."
 msgstr "Put fields on the right to display it. Flags are : '*' = mandatory ! 'number' = mandatory position ! '-' = if removed, field content will be emptied !"
 
-#: ./content/project.py:64
+#: ./browser/controlpanel.py:139
+msgid "Put states on the right for which you want to globalize budget fields."
+msgstr ""
+
+#: ./content/project.py:81
 msgid "Reached value"
 msgstr "Reached value"
 
-#: ./content/project.py:97
+#: ./content/project.py:124
 msgid "Reference number"
 msgstr ""
 
-#: ./content/project.py:166
+#: ./content/project.py:193
 msgid "Result indicator"
 msgstr "Result indicator"
 
-#: ./browser/controlpanel.py:94
+#: ./browser/controlpanel.py:96
 msgid "Some fields have to be at a specific position: ${msg}"
 msgstr ""
 
-#: ./testing.zcml:17
+#: ./testing.zcml:18
 msgid "Steps to ease tests of imio.project.core"
 msgstr ""
 
-#: ./browser/views.py:347
+#: ./browser/views.py:374
 msgid "The XML document has been successfully imported."
 msgstr ""
 
-#: ./browser/views.py:341
+#: ./browser/views.py:368
 msgid "The imported document is not recognized as a valid eComptes export."
 msgstr ""
 
@@ -252,7 +256,7 @@ msgstr ""
 msgid "Used in Title, documents, etc."
 msgstr ""
 
-#: ./content/project.py:150
+#: ./content/project.py:177
 msgid "Visible for"
 msgstr "Visible for"
 
@@ -260,46 +264,46 @@ msgstr "Visible for"
 msgid "Will contain projects sharing same configuration values"
 msgstr "Will contain projects sharing same configuration values"
 
-#: ./browser/views.py:251
+#: ./browser/views.py:272
 msgid "XML document exported from eComptes"
 msgstr ""
 
-#: ./browser/behaviors.py:23
-#: ./content/project.py:68
+#: ./browser/behaviors.py:40
+#: ./content/project.py:85
 msgid "Year"
 msgstr ""
 
 #. Default: "Expenses"
-#: ../browser/analytic_budget_datagridfield_display.pt:23
+#: ./browser/analytic_budget_datagridfield_display.pt:23
 msgid "analytic_budget_label_expenses"
 msgstr ""
 
 #. Default: "Revenues"
-#: ../browser/analytic_budget_datagridfield_display.pt:22
+#: ./browser/analytic_budget_datagridfield_display.pt:22
 msgid "analytic_budget_label_revenues"
 msgstr ""
 
 #. Default: "Total"
-#: ../browser/analytic_budget_datagridfield_display.pt:24
+#: ./browser/analytic_budget_datagridfield_display.pt:24
 msgid "analytic_budget_label_total"
 msgstr ""
 
 #. Default: "Year"
-#: ../browser/analytic_budget_datagridfield_display.pt:21
+#: ./browser/analytic_budget_datagridfield_display.pt:21
 msgid "analytic_budget_label_year"
 msgstr ""
 
 #. Default: "Data taken from analytic budgets encoded in sub-element"
-#: ../browser/analytic_budget_datagridfield_display.pt:16
+#: ./browser/analytic_budget_datagridfield_display.pt:16
 msgid "analytic_budget_legend_global_data"
 msgstr ""
 
 #. Default: "Locally encoded data"
-#: ../browser/analytic_budget_datagridfield_display.pt:10
+#: ./browser/analytic_budget_datagridfield_display.pt:10
 msgid "analytic_budget_legend_local_data"
 msgstr ""
 
-#: ../browser/behaviors.zcml:14
+#: ./browser/behaviors.zcml:14
 msgid "behavior.AnalyticBudget"
 msgstr ""
 
@@ -327,40 +331,44 @@ msgstr ""
 msgid "for '${type}' type => ${fields}. "
 msgstr ""
 
-#: ./configure.zcml:31
+#: ./configure.zcml:32
 msgid "imio.project.core"
 msgstr ""
 
-#: ./testing.zcml:17
+#: ./testing.zcml:18
 msgid "imio.project.core tests"
 msgstr ""
 
+#: ./browser/controlpanel.py:55
+msgid "project"
+msgstr ""
+
 #. Default: "R/D"
-#: ../browser/projection_datagridfield_display.pt:15
+#: ./browser/projection_datagridfield_display.pt:15
 msgid "projection_label_btype"
 msgstr ""
 
 #. Default: "Eco group"
-#: ../browser/projection_datagridfield_display.pt:16
+#: ./browser/projection_datagridfield_display.pt:16
 msgid "projection_label_group"
 msgstr ""
 
 #. Default: "Service"
-#: ../browser/projection_datagridfield_display.pt:14
+#: ./browser/projection_datagridfield_display.pt:14
 msgid "projection_label_service"
 msgstr ""
 
 #. Default: "Title"
-#: ../browser/projection_datagridfield_display.pt:17
+#: ./browser/projection_datagridfield_display.pt:17
 msgid "projection_label_title"
 msgstr ""
 
 #. Default: "Data taken from budget infos encoded in sub-element"
-#: ../browser/projection_datagridfield_display.pt:41
+#: ./browser/projection_datagridfield_display.pt:41
 msgid "projection_legend_global_data"
 msgstr ""
 
 #. Default: "Locally encoded data"
-#: ../browser/projection_datagridfield_display.pt:9
+#: ./browser/projection_datagridfield_display.pt:9
 msgid "projection_legend_local_data"
 msgstr ""

--- a/src/imio/project/core/locales/fr/LC_MESSAGES/imio.project.core.po
+++ b/src/imio/project/core/locales/fr/LC_MESSAGES/imio.project.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-11 09:34+0000\n"
+"POT-Creation-Date: 2020-03-27 14:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,11 @@ msgstr ""
 "Domain: imio.project.core\n"
 "X-is-fallback-for: fr-fr fr-be fr-ca\n"
 
-#: ./browser/controlpanel.py:113
+#: ./browser/controlpanel.py:138
+msgid "${type} budget globalization states"
+msgstr "États à considérer pour la globalisation des champs financiers du type ${type}"
+
+#: ./browser/controlpanel.py:131
 msgid "${type} fields display"
 msgstr "Affichage et ordre des champs du type ${type}"
 
@@ -23,12 +27,12 @@ msgstr "Affichage et ordre des champs du type ${type}"
 msgid "'${fld}' at position ${i}"
 msgstr "'${fld}' à la position ${i}"
 
-#: ./browser/behaviors.py:47
-#: ./content/project.py:89
+#: ./browser/behaviors.py:64
+#: ./content/project.py:106
 msgid "Amount"
 msgstr "Montant"
 
-#: ./browser/behaviors.py:102
+#: ./browser/behaviors.py:119
 msgid "Analytic budget"
 msgstr "Budget analytique"
 
@@ -40,31 +44,31 @@ msgstr "Annexes"
 msgid "Behavior with analytic budget fields"
 msgstr "Behavior avec les champs de budget analytique"
 
-#: ./content/project.py:119
+#: ./content/project.py:146
 msgid "Budget"
 msgstr "Financement/Budget"
 
-#: ./browser/behaviors.py:38
+#: ./browser/behaviors.py:55
 msgid "Budget Article"
 msgstr "Article du budget"
 
-#: ./browser/behaviors.py:67
+#: ./browser/behaviors.py:84
 msgid "Budget Group"
 msgstr "Groupe économique"
 
-#: ./browser/behaviors.py:30
+#: ./browser/behaviors.py:47
 msgid "Budget Service"
 msgstr "Service"
 
-#: ./browser/behaviors.py:43
+#: ./browser/behaviors.py:60
 msgid "Budget Title"
 msgstr "Intitulé"
 
-#: ./browser/behaviors.py:34
+#: ./browser/behaviors.py:51
 msgid "Budget Type"
 msgstr "Type"
 
-#: ./content/project.py:130
+#: ./content/project.py:157
 msgid "Budget comments"
 msgstr "Commentaires sur le financement/budget"
 
@@ -76,11 +80,11 @@ msgstr "Années budget"
 msgid "Budget types values"
 msgstr "Types de budget possibles"
 
-#: ./content/project.py:78
+#: ./content/project.py:95
 msgid "Budget_type"
 msgstr "Type de budget"
 
-#: ./content/project.py:105
+#: ./content/project.py:131
 msgid "Categories"
 msgstr "Catégories"
 
@@ -88,7 +92,7 @@ msgstr "Catégories"
 msgid "Categories values"
 msgstr "Catégories possibles"
 
-#: ./content/project.py:225
+#: ./content/project.py:252
 msgid "Comments"
 msgstr "Commentaires"
 
@@ -96,11 +100,11 @@ msgstr "Commentaires"
 msgid "Current fiscal year"
 msgstr "Exercice en cours"
 
-#: ./content/project.py:185
+#: ./content/project.py:212
 msgid "Effective begin date"
 msgstr "Date de début effective"
 
-#: ./content/project.py:201
+#: ./content/project.py:228
 msgid "Effective end date"
 msgstr "Date de fin effective"
 
@@ -108,15 +112,15 @@ msgstr "Date de fin effective"
 msgid "Enter one different value by row. Label is the displayed value. Key is the stored value: in lowercase, without space."
 msgstr "Entrer une valeur différente par ligne. Le libellé est la valeur affichée. La clé est la valeur stockée: en minuscule, sans espace, sans accent."
 
-#: ./content/project.py:167
+#: ./content/project.py:194
 msgid "Enter one indicator by row. Value is a number. Label must precise the signification of this number."
 msgstr "Entrer un indicateur par ligne. La valeur est un nombre. Le libellé doit préciser la signification de ce nombre."
 
-#: ./content/project.py:61
+#: ./content/project.py:78
 msgid "Expected value"
 msgstr "Valeur à atteindre"
 
-#: ./content/project.py:159
+#: ./content/project.py:186
 msgid "Extra concerned people"
 msgstr "Partenaires externes"
 
@@ -124,15 +128,15 @@ msgstr "Partenaires externes"
 msgid "INS Code"
 msgstr "Code INS"
 
-#: ./browser/views.py:331
+#: ./browser/views.py:358
 msgid "Import"
 msgstr "Importer"
 
-#: ./browser/views.py:258
+#: ./browser/views.py:279
 msgid "Import data from eComptes"
 msgstr "Importer les données depuis eComptes"
 
-#: ./configure.zcml:31
+#: ./configure.zcml:32
 msgid "Installs the imio.project.core add-on."
 msgstr "Installs the imio.project.core add-on."
 
@@ -140,7 +144,7 @@ msgstr "Installs the imio.project.core add-on."
 msgid "Key"
 msgstr "Clé"
 
-#: ./content/project.py:58
+#: ./content/project.py:75
 #: ./content/projectspace.py:138
 msgid "Label"
 msgstr "Libellé"
@@ -149,31 +153,27 @@ msgstr "Libellé"
 msgid "Last reference number"
 msgstr "Dernier numéro de référence"
 
-#: ./content/project.py:139
+#: ./content/project.py:166
 msgid "Manager"
 msgstr "Gestionnaire"
 
-#: ./browser/controlpanel.py:72
+#: ./browser/controlpanel.py:74
 msgid "Missing mandatory fields: ${msg}"
 msgstr "Des champs obligatoires sont manquants: ${msg}"
 
-#: ./content/project.py:216
+#: ./content/project.py:243
 msgid "Observation"
 msgstr "Constat"
 
-#: ./content/project.py:177
+#: ./content/project.py:204
 msgid "Planned begin date"
 msgstr "Date de début prévue"
 
-#: ./content/project.py:193
+#: ./content/project.py:220
 msgid "Planned end date"
 msgstr "Échéance"
 
-#: ./content/project.py:217
-msgid "Prior determination"
-msgstr "Constat préalable"
-
-#: ./content/project.py:113
+#: ./content/project.py:140
 msgid "Priority"
 msgstr "Priorité"
 
@@ -181,20 +181,20 @@ msgstr "Priorité"
 msgid "Priority values"
 msgstr "Priorités possibles"
 
-#: ./content/project.py:209
+#: ./content/project.py:236
 msgid "Progress"
 msgstr "Progression"
 
-#: ./content/project.py:210
+#: ./content/project.py:237
 msgid "Progress estimation in %."
 msgstr "Entrer la progression en %."
 
-#: ./browser/controlpanel.py:113
+#: ./browser/controlpanel.py:131
 #: ./profiles/default/types/project.xml
 msgid "Project"
 msgstr "Projet"
 
-#: ./browser/controlpanel.py:131
+#: ./browser/controlpanel.py:155
 #: ./profiles/default/controlpanel.xml
 msgid "Project settings"
 msgstr "Gestion de projet"
@@ -203,39 +203,43 @@ msgstr "Gestion de projet"
 msgid "Project space"
 msgstr "Espace de projets"
 
-#: ./browser/behaviors.py:112
+#: ./browser/behaviors.py:129
 msgid "Projection"
 msgstr "Projections"
 
-#: ./browser/controlpanel.py:114
+#: ./browser/controlpanel.py:132
 msgid "Put fields on the right to display it. Flags are : ..."
 msgstr "Placer les champs à droite pour les afficher. Les indicateurs après le nom du champ signifient : <ul><li>* = obligatoire ! </li><li>nombre = position obligatoire ! </li><li>- = si retiré, le contenu du champ va être supprimé !</li></ul>"
 
-#: ./content/project.py:64
+#: ./browser/controlpanel.py:139
+msgid "Put states on the right for which you want to globalize budget fields."
+msgstr "Placer les états à droite pour en tenir compte."
+
+#: ./content/project.py:81
 msgid "Reached value"
 msgstr "Valeur déjà atteinte"
 
-#: ./content/project.py:97
+#: ./content/project.py:124
 msgid "Reference number"
 msgstr "Numéro de référence"
 
-#: ./content/project.py:166
+#: ./content/project.py:193
 msgid "Result indicator"
 msgstr "Indicateur de résultat"
 
-#: ./browser/controlpanel.py:94
+#: ./browser/controlpanel.py:96
 msgid "Some fields have to be at a specific position: ${msg}"
 msgstr "Certains champs doivent être à une position précise: ${msg}"
 
-#: ./testing.zcml:17
+#: ./testing.zcml:18
 msgid "Steps to ease tests of imio.project.core"
 msgstr "Steps to ease tests of imio.project.core"
 
-#: ./browser/views.py:347
+#: ./browser/views.py:374
 msgid "The XML document has been successfully imported."
 msgstr "Le document XML a été importé avec succès."
 
-#: ./browser/views.py:341
+#: ./browser/views.py:368
 msgid "The imported document is not recognized as a valid eComptes export."
 msgstr "Le document soumis n'est pas reconnu comme un export eComptes valide."
 
@@ -252,7 +256,7 @@ msgstr "Utiliser le numéro de référence"
 msgid "Used in Title, documents, etc."
 msgstr "Utilisé dans le titre, les documents, etc."
 
-#: ./content/project.py:150
+#: ./content/project.py:177
 msgid "Visible for"
 msgstr "Visible pour"
 
@@ -260,12 +264,12 @@ msgstr "Visible pour"
 msgid "Will contain projects sharing same configuration values"
 msgstr "Espace pour des projets partageant la même configuration"
 
-#: ./browser/views.py:251
+#: ./browser/views.py:272
 msgid "XML document exported from eComptes"
 msgstr "Document XML exporté d'eComptes"
 
-#: ./browser/behaviors.py:23
-#: ./content/project.py:68
+#: ./browser/behaviors.py:40
+#: ./content/project.py:85
 msgid "Year"
 msgstr "Année"
 
@@ -327,13 +331,17 @@ msgstr "Informations budgétaires encodées sur l'élément courant"
 msgid "for '${type}' type => ${fields}. "
 msgstr "pour le type '${type}' => ${fields}. "
 
-#: ./configure.zcml:31
+#: ./configure.zcml:32
 msgid "imio.project.core"
 msgstr "imio.project.core"
 
-#: ./testing.zcml:17
+#: ./testing.zcml:18
 msgid "imio.project.core tests"
 msgstr "imio.project.core tests"
+
+#: ./browser/controlpanel.py:55
+msgid "project"
+msgstr "projet"
 
 #. Default: "R/D"
 #: ./browser/projection_datagridfield_display.pt:15

--- a/src/imio/project/core/locales/fr/LC_MESSAGES/imio.project.core.po
+++ b/src/imio/project/core/locales/fr/LC_MESSAGES/imio.project.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-24 14:16+0000\n"
+"POT-Creation-Date: 2020-03-11 09:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -269,6 +269,36 @@ msgstr "Document XML exporté d'eComptes"
 msgid "Year"
 msgstr "Année"
 
+#. Default: "Expenses"
+#: ./browser/analytic_budget_datagridfield_display.pt:23
+msgid "analytic_budget_label_expenses"
+msgstr "Dépenses"
+
+#. Default: "Revenues"
+#: ./browser/analytic_budget_datagridfield_display.pt:22
+msgid "analytic_budget_label_revenues"
+msgstr "Recettes"
+
+#. Default: "Total"
+#: ./browser/analytic_budget_datagridfield_display.pt:24
+msgid "analytic_budget_label_total"
+msgstr "Total"
+
+#. Default: "Year"
+#: ./browser/analytic_budget_datagridfield_display.pt:21
+msgid "analytic_budget_label_year"
+msgstr "Année"
+
+#. Default: "Data taken from analytic budgets encoded in sub-element"
+#: ./browser/analytic_budget_datagridfield_display.pt:16
+msgid "analytic_budget_legend_global_data"
+msgstr "Budgets analytiques collectés sur les sous-éléments"
+
+#. Default: "Locally encoded data"
+#: ./browser/analytic_budget_datagridfield_display.pt:10
+msgid "analytic_budget_legend_local_data"
+msgstr "Budgets analytiques encodés sur l'élément courant"
+
 #: ./browser/behaviors.zcml:14
 msgid "behavior.AnalyticBudget"
 msgstr "behavior.AnalyticBudget"
@@ -305,6 +335,32 @@ msgstr "imio.project.core"
 msgid "imio.project.core tests"
 msgstr "imio.project.core tests"
 
-#: ./browser/controlpanel.py:55
-msgid "project"
-msgstr "Projet"
+#. Default: "R/D"
+#: ./browser/projection_datagridfield_display.pt:15
+msgid "projection_label_btype"
+msgstr "R/D"
+
+#. Default: "Eco group"
+#: ./browser/projection_datagridfield_display.pt:16
+msgid "projection_label_group"
+msgstr "Groupe éco"
+
+#. Default: "Service"
+#: ./browser/projection_datagridfield_display.pt:14
+msgid "projection_label_service"
+msgstr "Service"
+
+#. Default: "Title"
+#: ./browser/projection_datagridfield_display.pt:17
+msgid "projection_label_title"
+msgstr "Intitulé"
+
+#. Default: "Data taken from budget infos encoded in sub-element"
+#: ./browser/projection_datagridfield_display.pt:41
+msgid "projection_legend_global_data"
+msgstr "Projections collectées sur les sous-éléments"
+
+#. Default: "Locally encoded data"
+#: ./browser/projection_datagridfield_display.pt:9
+msgid "projection_legend_local_data"
+msgstr "Projections encodées sur l'élément courant"

--- a/src/imio/project/core/locales/imio.project.core.pot
+++ b/src/imio/project/core/locales/imio.project.core.pot
@@ -271,7 +271,37 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: ./browser/behaviors.zcml:14
+#. Default: "Expenses"
+#: ../browser/analytic_budget_datagridfield_display.pt:23
+msgid "analytic_budget_label_expenses"
+msgstr ""
+
+#. Default: "Revenues"
+#: ../browser/analytic_budget_datagridfield_display.pt:22
+msgid "analytic_budget_label_revenues"
+msgstr ""
+
+#. Default: "Total"
+#: ../browser/analytic_budget_datagridfield_display.pt:24
+msgid "analytic_budget_label_total"
+msgstr ""
+
+#. Default: "Year"
+#: ../browser/analytic_budget_datagridfield_display.pt:21
+msgid "analytic_budget_label_year"
+msgstr ""
+
+#. Default: "Data taken from analytic budgets encoded in sub-element"
+#: ../browser/analytic_budget_datagridfield_display.pt:16
+msgid "analytic_budget_legend_global_data"
+msgstr ""
+
+#. Default: "Locally encoded data"
+#: ../browser/analytic_budget_datagridfield_display.pt:10
+msgid "analytic_budget_legend_local_data"
+msgstr ""
+
+#: ../browser/behaviors.zcml:14
 msgid "behavior.AnalyticBudget"
 msgstr ""
 
@@ -307,6 +337,32 @@ msgstr ""
 msgid "imio.project.core tests"
 msgstr ""
 
-#: ./browser/controlpanel.py:55
-msgid "project"
+#. Default: "R/D"
+#: ../browser/projection_datagridfield_display.pt:15
+msgid "projection_label_btype"
+msgstr ""
+
+#. Default: "Eco group"
+#: ../browser/projection_datagridfield_display.pt:16
+msgid "projection_label_group"
+msgstr ""
+
+#. Default: "Service"
+#: ../browser/projection_datagridfield_display.pt:14
+msgid "projection_label_service"
+msgstr ""
+
+#. Default: "Title"
+#: ../browser/projection_datagridfield_display.pt:17
+msgid "projection_label_title"
+msgstr ""
+
+#. Default: "Data taken from budget infos encoded in sub-element"
+#: ../browser/projection_datagridfield_display.pt:41
+msgid "projection_legend_global_data"
+msgstr ""
+
+#. Default: "Locally encoded data"
+#: ../browser/projection_datagridfield_display.pt:9
+msgid "projection_legend_local_data"
 msgstr ""

--- a/src/imio/project/core/locales/imio.project.core.pot
+++ b/src/imio/project/core/locales/imio.project.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-02-24 14:16+0000\n"
+"POT-Creation-Date: 2020-03-27 14:49+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: imio.project.core\n"
 
-#: ./browser/controlpanel.py:113
+#: ./browser/controlpanel.py:138
+msgid "${type} budget globalization states"
+msgstr ""
+
+#: ./browser/controlpanel.py:131
 msgid "${type} fields display"
 msgstr ""
 
@@ -25,12 +29,12 @@ msgstr ""
 msgid "'${fld}' at position ${i}"
 msgstr ""
 
-#: ./browser/behaviors.py:47
-#: ./content/project.py:89
+#: ./browser/behaviors.py:64
+#: ./content/project.py:106
 msgid "Amount"
 msgstr ""
 
-#: ./browser/behaviors.py:102
+#: ./browser/behaviors.py:119
 msgid "Analytic budget"
 msgstr ""
 
@@ -42,31 +46,31 @@ msgstr ""
 msgid "Behavior with analytic budget fields"
 msgstr ""
 
-#: ./content/project.py:119
+#: ./content/project.py:146
 msgid "Budget"
 msgstr ""
 
-#: ./browser/behaviors.py:38
+#: ./browser/behaviors.py:55
 msgid "Budget Article"
 msgstr ""
 
-#: ./browser/behaviors.py:67
+#: ./browser/behaviors.py:84
 msgid "Budget Group"
 msgstr ""
 
-#: ./browser/behaviors.py:30
+#: ./browser/behaviors.py:47
 msgid "Budget Service"
 msgstr ""
 
-#: ./browser/behaviors.py:43
+#: ./browser/behaviors.py:60
 msgid "Budget Title"
 msgstr ""
 
-#: ./browser/behaviors.py:34
+#: ./browser/behaviors.py:51
 msgid "Budget Type"
 msgstr ""
 
-#: ./content/project.py:130
+#: ./content/project.py:157
 msgid "Budget comments"
 msgstr ""
 
@@ -78,11 +82,11 @@ msgstr ""
 msgid "Budget types values"
 msgstr ""
 
-#: ./content/project.py:78
+#: ./content/project.py:95
 msgid "Budget_type"
 msgstr ""
 
-#: ./content/project.py:105
+#: ./content/project.py:131
 msgid "Categories"
 msgstr ""
 
@@ -90,7 +94,7 @@ msgstr ""
 msgid "Categories values"
 msgstr ""
 
-#: ./content/project.py:225
+#: ./content/project.py:252
 msgid "Comments"
 msgstr ""
 
@@ -98,11 +102,11 @@ msgstr ""
 msgid "Current fiscal year"
 msgstr ""
 
-#: ./content/project.py:185
+#: ./content/project.py:212
 msgid "Effective begin date"
 msgstr ""
 
-#: ./content/project.py:201
+#: ./content/project.py:228
 msgid "Effective end date"
 msgstr ""
 
@@ -110,15 +114,15 @@ msgstr ""
 msgid "Enter one different value by row. Label is the displayed value. Key is the stored value: in lowercase, without space."
 msgstr ""
 
-#: ./content/project.py:167
+#: ./content/project.py:194
 msgid "Enter one indicator by row. Value is a number. Label must precise the signification of this number."
 msgstr ""
 
-#: ./content/project.py:61
+#: ./content/project.py:78
 msgid "Expected value"
 msgstr ""
 
-#: ./content/project.py:159
+#: ./content/project.py:186
 msgid "Extra concerned people"
 msgstr ""
 
@@ -126,15 +130,15 @@ msgstr ""
 msgid "INS Code"
 msgstr ""
 
-#: ./browser/views.py:331
+#: ./browser/views.py:358
 msgid "Import"
 msgstr ""
 
-#: ./browser/views.py:258
+#: ./browser/views.py:279
 msgid "Import data from eComptes"
 msgstr ""
 
-#: ./configure.zcml:31
+#: ./configure.zcml:32
 msgid "Installs the imio.project.core add-on."
 msgstr ""
 
@@ -142,7 +146,7 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-#: ./content/project.py:58
+#: ./content/project.py:75
 #: ./content/projectspace.py:138
 msgid "Label"
 msgstr ""
@@ -151,31 +155,27 @@ msgstr ""
 msgid "Last reference number"
 msgstr ""
 
-#: ./content/project.py:139
+#: ./content/project.py:166
 msgid "Manager"
 msgstr ""
 
-#: ./browser/controlpanel.py:72
+#: ./browser/controlpanel.py:74
 msgid "Missing mandatory fields: ${msg}"
 msgstr ""
 
-#: ./content/project.py:216
+#: ./content/project.py:243
 msgid "Observation"
 msgstr ""
 
-#: ./content/project.py:177
+#: ./content/project.py:204
 msgid "Planned begin date"
 msgstr ""
 
-#: ./content/project.py:193
+#: ./content/project.py:220
 msgid "Planned end date"
 msgstr ""
 
-#: ./content/project.py:217
-msgid "Prior determination"
-msgstr ""
-
-#: ./content/project.py:113
+#: ./content/project.py:140
 msgid "Priority"
 msgstr ""
 
@@ -183,20 +183,20 @@ msgstr ""
 msgid "Priority values"
 msgstr ""
 
-#: ./content/project.py:209
+#: ./content/project.py:236
 msgid "Progress"
 msgstr ""
 
-#: ./content/project.py:210
+#: ./content/project.py:237
 msgid "Progress estimation in %."
 msgstr ""
 
-#: ./browser/controlpanel.py:113
+#: ./browser/controlpanel.py:131
 #: ./profiles/default/types/project.xml
 msgid "Project"
 msgstr ""
 
-#: ./browser/controlpanel.py:131
+#: ./browser/controlpanel.py:155
 #: ./profiles/default/controlpanel.xml
 msgid "Project settings"
 msgstr ""
@@ -205,39 +205,43 @@ msgstr ""
 msgid "Project space"
 msgstr ""
 
-#: ./browser/behaviors.py:112
+#: ./browser/behaviors.py:129
 msgid "Projection"
 msgstr ""
 
-#: ./browser/controlpanel.py:114
+#: ./browser/controlpanel.py:132
 msgid "Put fields on the right to display it. Flags are : ..."
 msgstr ""
 
-#: ./content/project.py:64
+#: ./browser/controlpanel.py:139
+msgid "Put states on the right for which you want to globalize budget fields."
+msgstr ""
+
+#: ./content/project.py:81
 msgid "Reached value"
 msgstr ""
 
-#: ./content/project.py:97
+#: ./content/project.py:124
 msgid "Reference number"
 msgstr ""
 
-#: ./content/project.py:166
+#: ./content/project.py:193
 msgid "Result indicator"
 msgstr ""
 
-#: ./browser/controlpanel.py:94
+#: ./browser/controlpanel.py:96
 msgid "Some fields have to be at a specific position: ${msg}"
 msgstr ""
 
-#: ./testing.zcml:17
+#: ./testing.zcml:18
 msgid "Steps to ease tests of imio.project.core"
 msgstr ""
 
-#: ./browser/views.py:347
+#: ./browser/views.py:374
 msgid "The XML document has been successfully imported."
 msgstr ""
 
-#: ./browser/views.py:341
+#: ./browser/views.py:368
 msgid "The imported document is not recognized as a valid eComptes export."
 msgstr ""
 
@@ -254,7 +258,7 @@ msgstr ""
 msgid "Used in Title, documents, etc."
 msgstr ""
 
-#: ./content/project.py:150
+#: ./content/project.py:177
 msgid "Visible for"
 msgstr ""
 
@@ -262,46 +266,46 @@ msgstr ""
 msgid "Will contain projects sharing same configuration values"
 msgstr ""
 
-#: ./browser/views.py:251
+#: ./browser/views.py:272
 msgid "XML document exported from eComptes"
 msgstr ""
 
-#: ./browser/behaviors.py:23
-#: ./content/project.py:68
+#: ./browser/behaviors.py:40
+#: ./content/project.py:85
 msgid "Year"
 msgstr ""
 
 #. Default: "Expenses"
-#: ../browser/analytic_budget_datagridfield_display.pt:23
+#: ./browser/analytic_budget_datagridfield_display.pt:23
 msgid "analytic_budget_label_expenses"
 msgstr ""
 
 #. Default: "Revenues"
-#: ../browser/analytic_budget_datagridfield_display.pt:22
+#: ./browser/analytic_budget_datagridfield_display.pt:22
 msgid "analytic_budget_label_revenues"
 msgstr ""
 
 #. Default: "Total"
-#: ../browser/analytic_budget_datagridfield_display.pt:24
+#: ./browser/analytic_budget_datagridfield_display.pt:24
 msgid "analytic_budget_label_total"
 msgstr ""
 
 #. Default: "Year"
-#: ../browser/analytic_budget_datagridfield_display.pt:21
+#: ./browser/analytic_budget_datagridfield_display.pt:21
 msgid "analytic_budget_label_year"
 msgstr ""
 
 #. Default: "Data taken from analytic budgets encoded in sub-element"
-#: ../browser/analytic_budget_datagridfield_display.pt:16
+#: ./browser/analytic_budget_datagridfield_display.pt:16
 msgid "analytic_budget_legend_global_data"
 msgstr ""
 
 #. Default: "Locally encoded data"
-#: ../browser/analytic_budget_datagridfield_display.pt:10
+#: ./browser/analytic_budget_datagridfield_display.pt:10
 msgid "analytic_budget_legend_local_data"
 msgstr ""
 
-#: ../browser/behaviors.zcml:14
+#: ./browser/behaviors.zcml:14
 msgid "behavior.AnalyticBudget"
 msgstr ""
 
@@ -329,40 +333,44 @@ msgstr ""
 msgid "for '${type}' type => ${fields}. "
 msgstr ""
 
-#: ./configure.zcml:31
+#: ./configure.zcml:32
 msgid "imio.project.core"
 msgstr ""
 
-#: ./testing.zcml:17
+#: ./testing.zcml:18
 msgid "imio.project.core tests"
 msgstr ""
 
+#: ./browser/controlpanel.py:55
+msgid "project"
+msgstr ""
+
 #. Default: "R/D"
-#: ../browser/projection_datagridfield_display.pt:15
+#: ./browser/projection_datagridfield_display.pt:15
 msgid "projection_label_btype"
 msgstr ""
 
 #. Default: "Eco group"
-#: ../browser/projection_datagridfield_display.pt:16
+#: ./browser/projection_datagridfield_display.pt:16
 msgid "projection_label_group"
 msgstr ""
 
 #. Default: "Service"
-#: ../browser/projection_datagridfield_display.pt:14
+#: ./browser/projection_datagridfield_display.pt:14
 msgid "projection_label_service"
 msgstr ""
 
 #. Default: "Title"
-#: ../browser/projection_datagridfield_display.pt:17
+#: ./browser/projection_datagridfield_display.pt:17
 msgid "projection_label_title"
 msgstr ""
 
 #. Default: "Data taken from budget infos encoded in sub-element"
-#: ../browser/projection_datagridfield_display.pt:41
+#: ./browser/projection_datagridfield_display.pt:41
 msgid "projection_legend_global_data"
 msgstr ""
 
 #. Default: "Locally encoded data"
-#: ../browser/projection_datagridfield_display.pt:9
+#: ./browser/projection_datagridfield_display.pt:9
 msgid "projection_legend_local_data"
 msgstr ""

--- a/src/imio/project/core/migrations/migrate_to_1_3.py
+++ b/src/imio/project/core/migrations/migrate_to_1_3.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from imio.migrator.migrator import Migrator
+from imio.project.core.config import SUMMARIZED_FIELDS
 from imio.project.core.content.project import IProject
 from imio.project.core.content.projectspace import IProjectSpace
+from imio.project.core.events import _updateSummarizedFields
 from plone import api
 from Products.CMFPlone.utils import base_hasattr
+from zope.annotation import IAnnotations
 
 import logging
 
@@ -17,7 +20,6 @@ class Migrate_To_1_3(Migrator):
         Migrator.__init__(self, context)
 
     def run(self):
-
         # moved categories ps attribute to renamed attribute
         catalog = api.portal.get_tool('portal_catalog')
         brains = catalog.searchResults(object_provides=IProjectSpace.__identifier__)
@@ -30,10 +32,19 @@ class Migrate_To_1_3(Migrator):
                 delattr(obj, old)
                 obj.reindexObject()
 
-        # reindex projects too
-        brains = catalog.searchResults(object_provides=IProject.__identifier__)
+        # clean annotations and reindex to correct link
+        brains = catalog.searchResults(object_provides=IProject.__identifier__, sort_on='path', sort_order='reverse')
         for brain in brains:
-            brain.getObject().reindexObject()
+            obj = brain.getObject()
+            obj_annotations = IAnnotations(obj)
+            for fld, AK in SUMMARIZED_FIELDS.items():
+                if AK in obj_annotations:
+                    del obj_annotations[AK]
+            obj.reindexObject()
+
+        brains = catalog.searchResults(object_provides=IProject.__identifier__, sort_on='path', sort_order='reverse')
+        for brain in brains:
+            _updateSummarizedFields(brain.getObject())
 
         # Display duration
         self.finish()

--- a/src/imio/project/core/migrations/migrate_to_1_3.py
+++ b/src/imio/project/core/migrations/migrate_to_1_3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from imio.migrator.migrator import Migrator
+from imio.project.core.browser.controlpanel import get_budget_states
 from imio.project.core.config import SUMMARIZED_FIELDS
 from imio.project.core.content.project import IProject
 from imio.project.core.content.projectspace import IProjectSpace
@@ -37,14 +38,20 @@ class Migrate_To_1_3(Migrator):
         for brain in brains:
             obj = brain.getObject()
             obj_annotations = IAnnotations(obj)
+            changed = False
             for fld, AK in SUMMARIZED_FIELDS.items():
                 if AK in obj_annotations:
+                    changed = True
                     del obj_annotations[AK]
-            obj.reindexObject()
+            if changed:
+                obj.reindexObject()
 
         brains = catalog.searchResults(object_provides=IProject.__identifier__, sort_on='path', sort_order='reverse')
+        pw = api.portal.get_tool('portal_workflow')
         for brain in brains:
-            _updateSummarizedFields(brain.getObject())
+            obj = brain.getObject()
+            if pw.getInfoFor(obj, 'review_state') in get_budget_states(obj.portal_type):
+                _updateSummarizedFields(obj)
 
         # Display duration
         self.finish()

--- a/src/imio/project/core/testing.py
+++ b/src/imio/project/core/testing.py
@@ -2,6 +2,7 @@
 """Base module for unittesting."""
 
 from collective.contact.plonegroup.config import PLONEGROUP_ORG
+from plone import api
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import login
@@ -53,6 +54,9 @@ class FunctionalTestCase(unittest.TestCase):
         # login as Manager and add a projectspace and 2 projects into it
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         login(self.portal, TEST_USER_NAME)
+        # set registry config
+        api.portal.set_registry_record('imio.project.settings.project_budget_states',
+                                       ['to_be_scheduled', 'ongoing', 'terminated'])
         params = {'id': u"projectspace",
                   'title': u"projectspace"}
         # datagridfield categories


### PR DESCRIPTION
Cette partie contient:
- la mise à jour des annotations sur les parents, après modifications d'un élément du PST. J'ai adapté le code existant pour budgetinfos afin qu'il fonctionne aussi pour projection et analytic_budget.
- les 2 widgets qui affichent les données locales et globalisées.